### PR TITLE
Make coordinates optional while adding a user

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,8 +69,7 @@ def get_auth_token():
 
 
 @app.route('/hcf/users/<string:username>', methods=['POST'])
-@validate_json('name', 'email_id', 'password', 'phone', 'zipcode', 'longitude',
-               'latitude')
+@validate_json('name', 'email_id', 'password', 'phone', 'zipcode')
 def adduser(username):
     content = request.json
     user = models.Users.query.filter(


### PR DESCRIPTION
Testing done:

$ curl -i -X POST -H "Content-Type: application/json" -d '{"name":"Teja", "email_id":"teja@gmail.com", "phone": "4087181234", "zipcode":"95035","password":"python"}' http://127.0.0.1:5000/hcf/users/teja
HTTP/1.0 201 CREATED
Content-Type: application/json
Content-Length: 14
Server: Werkzeug/0.12.1 Python/3.5.1
Date: Wed, 26 Apr 2017 06:13:25 GMT

{
  "id": 4
}